### PR TITLE
Add dashboard endpoint and UI access

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,16 @@ Yes with Ollama, lm-studio or server providers, all speech to text, LLM and text
 This started as Side-Project we did out of interest about AI agents. What’s special about it is that we want to use local model and avoid APIs.
 We draw inspiration from Jarvis and Friday (Iron man movies) to make it "cool" but for functionality we take more inspiration from Manus, because that's what people want in the first place: a local manus alternative.
 Unlike Manus, AgenticSeek prioritizes independence from external systems, giving you more control, privacy and avoid api cost.
+## Memory Analytics Dashboard
+Generate an interactive overview of your conversations and knowledge graph:
+
+```sh
+python3 scripts/generate_memory_dashboard.py --open
+```
+
+Dashboard files are saved in `data/dashboard` by default.
+You can also open the dashboard from the web UI using the new **📊 Dashboard** button in the header.
+
 
 ## Contribute
 

--- a/frontend/agentic-seek-front/src/App.css
+++ b/frontend/agentic-seek-front/src/App.css
@@ -253,6 +253,27 @@ body {
   height: 40px;
 }
 
+.dashboard-button {
+  padding: var(--spacing-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+}
+
+.dashboard-button:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  transform: scale(1.05);
+}
+
 .theme-toggle:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
@@ -1238,6 +1259,7 @@ body {
   .input-form,
   .view-selector,
   .theme-toggle,
+  .dashboard-button,
   .reasoning-toggle {
     display: none !important;
   }

--- a/frontend/agentic-seek-front/src/App.css
+++ b/frontend/agentic-seek-front/src/App.css
@@ -280,6 +280,27 @@ body {
   transform: scale(1.05);
 }
 
+.clear-chat {
+  padding: var(--spacing-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+}
+
+.clear-chat:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  transform: scale(1.05);
+}
+
 /* Navigation Tabs */
 .section-tabs {
   display: flex;
@@ -617,8 +638,9 @@ body {
 /* Message Header and Reasoning */
 .message-header {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
   gap: var(--spacing-sm);
   margin-bottom: var(--spacing-sm);
 }
@@ -648,6 +670,34 @@ body {
 
 .reasoning-toggle:active {
   transform: translateY(0);
+}
+
+.message-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.timestamp {
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+
+.copy-button {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--spacing-xs);
+  border-radius: var(--radius-md);
+  transition: var(--transition);
+  display: flex;
+  align-items: center;
+}
+
+.copy-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
 }
 
 .reasoning-content {

--- a/frontend/agentic-seek-front/src/App.js
+++ b/frontend/agentic-seek-front/src/App.js
@@ -150,6 +150,15 @@ function App() {
         }
     }
 
+    const handleOpenDashboard = async () => {
+        try {
+            await axios.get(`${BACKEND_URL}/memory_dashboard`);
+            window.open(`${BACKEND_URL}/dashboard/memory_dashboard.html`, '_blank');
+        } catch (err) {
+            console.error('Error opening dashboard:', err);
+        }
+    }
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         checkHealth();
@@ -205,12 +214,19 @@ function App() {
                     </div>
                 </div>
                 <div className="header-right">
-                    <button 
+                    <button
                         className="theme-toggle"
                         onClick={() => setDarkMode(!darkMode)}
                         title={`Switch to ${darkMode ? 'light' : 'dark'} mode`}
                     >
                         {darkMode ? '☀️' : '🌙'}
+                    </button>
+                    <button
+                        className="dashboard-button"
+                        onClick={handleOpenDashboard}
+                        title="Open Memory Dashboard"
+                    >
+                        📊
                     </button>
                 </div>
             </header>

--- a/frontend/agentic-seek-front/src/App.js
+++ b/frontend/agentic-seek-front/src/App.js
@@ -42,6 +42,18 @@ function App() {
         });
     };
 
+    const copyToClipboard = (text) => {
+        navigator.clipboard.writeText(text).catch(err => {
+            console.error('Copy failed:', err);
+        });
+    };
+
+    const formatTimestamp = (ts) => {
+        if (!ts) return '';
+        const d = new Date(ts);
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    };
+
     const checkHealth = async () => {
         try {
             await axios.get(`${BACKEND_URL}/health`);
@@ -104,6 +116,7 @@ function App() {
                         agentName: data.agent_name,
                         status: data.status,
                         uid: data.uid,
+                        timestamp: new Date().getTime(),
                     },
                 ]);
                 setStatus(data.status);
@@ -166,7 +179,7 @@ function App() {
             console.log('Empty query');
             return;
         }
-        setMessages((prev) => [...prev, { type: 'user', content: query }]);
+        setMessages((prev) => [...prev, { type: 'user', content: query, timestamp: new Date().getTime() }]);
         setIsLoading(true);
         setError(null);
 
@@ -195,6 +208,12 @@ function App() {
         }
     };
 
+    const handleClearChat = () => {
+        setMessages([]);
+        setResponseData(null);
+        setStatus('Agents ready');
+    };
+
     const handleGetScreenshot = async () => {
         try {
             setCurrentView('screenshot');
@@ -214,6 +233,13 @@ function App() {
                     </div>
                 </div>
                 <div className="header-right">
+                    <button
+                        className="clear-chat"
+                        onClick={handleClearChat}
+                        title="Clear chat"
+                    >
+                        🗑️
+                    </button>
                     <button
                         className="theme-toggle"
                         onClick={() => setDarkMode(!darkMode)}
@@ -252,22 +278,30 @@ function App() {
                                                     : 'error-message'
                                             }`}
                                         >
-                                            {msg.type === 'agent' && (
-                                                <div className="message-header">
-                                                    {msg.agentName && (
-                                                        <span className="agent-name">{msg.agentName}</span>
-                                                    )}
-                                                    {msg.reasoning && (
-                                                        <button 
+                                            <div className="message-header">
+                                                {msg.agentName && (
+                                                    <span className="agent-name">{msg.agentName}</span>
+                                                )}
+                                                <div className="message-actions">
+                                                    <span className="timestamp">{formatTimestamp(msg.timestamp)}</span>
+                                                    <button
+                                                        className="copy-button"
+                                                        onClick={() => copyToClipboard(msg.content)}
+                                                        title="Copy message"
+                                                    >
+                                                        📋
+                                                    </button>
+                                                    {msg.type === 'agent' && msg.reasoning && (
+                                                        <button
                                                             className="reasoning-toggle"
                                                             onClick={() => toggleReasoning(index)}
-                                                            title={expandedReasoning.has(index) ? "Hide reasoning" : "Show reasoning"}
+                                                            title={expandedReasoning.has(index) ? 'Hide reasoning' : 'Show reasoning'}
                                                         >
                                                             {expandedReasoning.has(index) ? '▼' : '▶'} Reasoning
                                                         </button>
                                                     )}
                                                 </div>
-                                            )}
+                                            </div>
                                             <div className="message-content">
                                                 <ReactMarkdown>{msg.content}</ReactMarkdown>
                                             </div>

--- a/scripts/generate_memory_dashboard.py
+++ b/scripts/generate_memory_dashboard.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Generate memory analytics dashboard for AgenticSeek."""
+
+import argparse
+from pathlib import Path
+import webbrowser
+
+from sources.knowledge.memoryIntegration import MemorySystemConfig, EnhancedMemorySystem
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create an interactive memory dashboard")
+    parser.add_argument("-o", "--output", default="./data/dashboard", help="Directory where dashboard files are saved")
+    parser.add_argument("--open", action="store_true", help="Open the generated dashboard in your browser")
+    args = parser.parse_args()
+
+    config = MemorySystemConfig(dashboard_path=args.output, enable_background_processing=False)
+    memory_system = EnhancedMemorySystem(config=config)
+
+    dashboard_path = memory_system.generate_dashboard()
+    memory_system.shutdown()
+
+    if dashboard_path:
+        print(f"Dashboard created at {dashboard_path}")
+        if args.open:
+            webbrowser.open(f"file://{Path(dashboard_path).resolve()}")
+    else:
+        print("Failed to generate dashboard")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- serve generated dashboards via `/dashboard`
- add API endpoint `/memory_dashboard` to generate dashboard
- add Dashboard button in React UI
- update README usage instructions

## Testing
- `python quick_verify.py` *(fails: No module named 'colorama')*
- `python test_llm_cache.py` *(fails: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_b_684b73ed6f38832c9fe2da023d6a8402