### PR TITLE
Enhance frontend UX

### DIFF
--- a/frontend/agentic-seek-front/src/App.css
+++ b/frontend/agentic-seek-front/src/App.css
@@ -259,6 +259,27 @@ body {
   transform: scale(1.05);
 }
 
+.clear-chat {
+  padding: var(--spacing-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+}
+
+.clear-chat:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  transform: scale(1.05);
+}
+
 /* Navigation Tabs */
 .section-tabs {
   display: flex;
@@ -596,8 +617,9 @@ body {
 /* Message Header and Reasoning */
 .message-header {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
   gap: var(--spacing-sm);
   margin-bottom: var(--spacing-sm);
 }
@@ -627,6 +649,34 @@ body {
 
 .reasoning-toggle:active {
   transform: translateY(0);
+}
+
+.message-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.timestamp {
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+
+.copy-button {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--spacing-xs);
+  border-radius: var(--radius-md);
+  transition: var(--transition);
+  display: flex;
+  align-items: center;
+}
+
+.copy-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
 }
 
 .reasoning-content {

--- a/frontend/agentic-seek-front/src/App.js
+++ b/frontend/agentic-seek-front/src/App.js
@@ -42,6 +42,18 @@ function App() {
         });
     };
 
+    const copyToClipboard = (text) => {
+        navigator.clipboard.writeText(text).catch(err => {
+            console.error('Copy failed:', err);
+        });
+    };
+
+    const formatTimestamp = (ts) => {
+        if (!ts) return '';
+        const d = new Date(ts);
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    };
+
     const checkHealth = async () => {
         try {
             await axios.get(`${BACKEND_URL}/health`);
@@ -104,6 +116,7 @@ function App() {
                         agentName: data.agent_name,
                         status: data.status,
                         uid: data.uid,
+                        timestamp: new Date().getTime(),
                     },
                 ]);
                 setStatus(data.status);
@@ -157,7 +170,7 @@ function App() {
             console.log('Empty query');
             return;
         }
-        setMessages((prev) => [...prev, { type: 'user', content: query }]);
+        setMessages((prev) => [...prev, { type: 'user', content: query, timestamp: new Date().getTime() }]);
         setIsLoading(true);
         setError(null);
 
@@ -186,6 +199,12 @@ function App() {
         }
     };
 
+    const handleClearChat = () => {
+        setMessages([]);
+        setResponseData(null);
+        setStatus('Agents ready');
+    };
+
     const handleGetScreenshot = async () => {
         try {
             setCurrentView('screenshot');
@@ -205,7 +224,14 @@ function App() {
                     </div>
                 </div>
                 <div className="header-right">
-                    <button 
+                    <button
+                        className="clear-chat"
+                        onClick={handleClearChat}
+                        title="Clear chat"
+                    >
+                        🗑️
+                    </button>
+                    <button
                         className="theme-toggle"
                         onClick={() => setDarkMode(!darkMode)}
                         title={`Switch to ${darkMode ? 'light' : 'dark'} mode`}
@@ -236,22 +262,30 @@ function App() {
                                                     : 'error-message'
                                             }`}
                                         >
-                                            {msg.type === 'agent' && (
-                                                <div className="message-header">
-                                                    {msg.agentName && (
-                                                        <span className="agent-name">{msg.agentName}</span>
-                                                    )}
-                                                    {msg.reasoning && (
-                                                        <button 
+                                            <div className="message-header">
+                                                {msg.agentName && (
+                                                    <span className="agent-name">{msg.agentName}</span>
+                                                )}
+                                                <div className="message-actions">
+                                                    <span className="timestamp">{formatTimestamp(msg.timestamp)}</span>
+                                                    <button
+                                                        className="copy-button"
+                                                        onClick={() => copyToClipboard(msg.content)}
+                                                        title="Copy message"
+                                                    >
+                                                        📋
+                                                    </button>
+                                                    {msg.type === 'agent' && msg.reasoning && (
+                                                        <button
                                                             className="reasoning-toggle"
                                                             onClick={() => toggleReasoning(index)}
-                                                            title={expandedReasoning.has(index) ? "Hide reasoning" : "Show reasoning"}
+                                                            title={expandedReasoning.has(index) ? 'Hide reasoning' : 'Show reasoning'}
                                                         >
                                                             {expandedReasoning.has(index) ? '▼' : '▶'} Reasoning
                                                         </button>
                                                     )}
                                                 </div>
-                                            )}
+                                            </div>
                                             <div className="message-content">
                                                 <ReactMarkdown>{msg.content}</ReactMarkdown>
                                             </div>


### PR DESCRIPTION
## Summary
- add copy-to-clipboard support and timestamps for messages
- provide button to clear chat
- show timestamps and copy button on messages
- style new buttons and metadata in the chat UI

## Testing
- `pytest -q` *(fails: Import error / SystemExit)*

------
https://chatgpt.com/codex/tasks/task_b_684b7a35df2c832ca8899b4c82c978d4