### PR TITLE
Fix duplicate dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         "selenium>=4.29.0",
         "markdownify>=1.1.0",
         "text2emotion>=0.0.5",
-        "python-dotenv>=1.0.0",
         "adaptive-classifier>=0.0.10",
         "langid>=1.1.6",
         "chromedriver-autoinstaller>=0.6.4",


### PR DESCRIPTION
## Summary
- remove the extra `python-dotenv` from `setup.py`

## Testing
- `pytest -q` *(fails: No module named 'colorama')*
- `python3 quick_verify.py` *(fails: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_b_684b8a810728832cb1871dc6a0862dd7