### PR TITLE
Fix uvicorn port setting

### DIFF
--- a/api.py
+++ b/api.py
@@ -280,4 +280,4 @@ if __name__ == "__main__":
         port = int(envport)
     else:
         port = 8000
-    uvicorn.run(api, host="0.0.0.0", port=8000)
+    uvicorn.run(api, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- use `BACKEND_PORT` env var to set uvicorn port

## Testing
- `python3 -m py_compile api.py`
- `pytest tests/test_memory.py -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_684b8a7b2bf4832c9fcb115cff9eb402