### PR TITLE
Fix shebang line in cli.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin python3
+#!/usr/bin/env python3
 
 import sys
 import argparse


### PR DESCRIPTION
## Summary
- update shebang to use `/usr/bin/env python3`

## Testing
- `pre-commit run --files cli.py` *(fails: trufflehog error)*

------
https://chatgpt.com/codex/tasks/task_b_684b8a7c8dec832ca06a48394d1feacc